### PR TITLE
change function YdResponse::new_raw()

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,8 @@ extern crate serde_derive;
 extern crate serde;
 extern crate serde_json;
 
-#[macro_use]
-extern crate structopt_derive;
+//#[macro_use]
+//extern crate structopt_derive;
 extern crate structopt;
 
 #[macro_use]
@@ -40,7 +40,7 @@ use formatters::{Formatter, PlainFormatter, AnsiFormatter, HtmlFormatter};
 
 fn lookup_explain(client: &mut Client, word: &str, fmt: &mut Formatter, raw: bool) {
     if raw {
-        println!("{}", client.lookup_word(word, true).unwrap().raw_result());
+        println!("{}", serde_json::to_string(&client.lookup_word(word, true).unwrap()).unwrap());
     } else {
         match client.lookup_word(word, false) {
             Ok(ref result) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,8 @@ extern crate serde_derive;
 extern crate serde;
 extern crate serde_json;
 
-//#[macro_use]
-//extern crate structopt_derive;
+#[macro_use]
+extern crate structopt_derive;
 extern crate structopt;
 
 #[macro_use]

--- a/src/ydclient.rs
+++ b/src/ydclient.rs
@@ -62,11 +62,11 @@ impl YdClient for Client {
             .send()?
             .read_to_string(&mut body)?;
 
-        let raw_result = YdResponse::new_raw(body);
+        let raw_result = YdResponse::new_raw(body.clone());
         if raw {
-            Ok(raw_result)
+            raw_result.map_err(Into::into)
         } else {
-            self.decode_result(&raw_result.raw_result())
+            self.decode_result(&body)
                 .map_err(Into::into)
         }
     }

--- a/src/ydresponse.rs
+++ b/src/ydresponse.rs
@@ -1,6 +1,7 @@
 //! parser for the returned result from YD
 
 use formatters::Formatter;
+use serde_json::{self, Error as SerdeError};
 
 /// Basic result structure
 #[derive(Serialize, Deserialize, Debug)]
@@ -31,18 +32,8 @@ pub struct YdResponse {
 
 
 impl YdResponse {
-    pub fn new_raw(result: String) -> YdResponse {
-        YdResponse {
-            query: result,
-            errorCode: 0,
-            basic: None,
-            translation: None,
-            web: None,
-        }
-    }
-
-    pub fn raw_result(&self) -> String {
-        self.query.clone()
+    pub fn new_raw(result: String) -> Result<YdResponse,SerdeError> {
+        serde_json::from_str(&result)
     }
 
     /// Explain the result in text format using a formatter


### PR DESCRIPTION
`lookup_word` 函数中 `YdResponse::new_raw()` 操作原先是直接抓取字符串写入到`YdRsponse`结构的`query`字段中，我觉得这种方法没有合理的构造出一个真正意义上的`YdResponse`
```
         self.get(url)
            // .header(Connection::close())
             .send()?
            .read_to_string(&mut body)?;

        let raw_result = YdResponse::new_raw(body);
        if raw {
            Ok(raw_result)
        } else {
            self.decode_result(&raw_result.raw_result())
.map_err(Into::into)
```