### PR TITLE
Cargo.toml: set rustls as feature to fix loongson3 arch build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ log = "^0.4"
 lazy_static = "^1.2"
 atty = "^0.2"
 htmlescape = "0.3"
-reqwest = {version = "0.11", default-features=false, features=["socks", "rustls-tls", "blocking"]}
+reqwest = {version = "0.11", default-features = false, features = ["socks", "blocking"]}
 rand = "0.8"
 md5 = "0.7"
 
@@ -32,9 +32,10 @@ notify-rust =           {version = "^3.4", optional = true}
 x11-clipboard =         {version = "^0.5", optional = true}
 
 [features]
-default = [ "notify", "clipboard" ]
+default = [ "notify", "clipboard", "rusttls" ]
 notify = ["notify-rust", "winrt-notification"]
 clipboard = ["x11-clipboard", "clipboard2"]
+rusttls = ["reqwest/rustls-tls"]
 
 [profile.release]
 lto = true


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/19554922/209900311-fbd86e0c-6b38-479b-aab7-120ee77a062b.png)

`ring` only support amd64, arm64 and riscv64 Architecture, More architectures (like Loongson3, ppc64el) could be supported if the user could manually turn off rusttls (and use openssl)