### PR TITLE
deps: use md-5 crate replace md5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,10 +869,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "md5"
-version = "0.7.0"
+name = "md-5"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+checksum = "6365506850d44bff6e2fbcb5176cf63650e48bd45ef2fe2665ae1570e0f4b9ca"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "memchr"
@@ -2415,7 +2418,7 @@ checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
 
 [[package]]
 name = "ydcv-rs"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "atty",
  "copypasta",
@@ -2423,7 +2426,7 @@ dependencies = [
  "htmlescape",
  "lazy_static",
  "log",
- "md5",
+ "md-5",
  "notify-rust",
  "rand",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ atty = "^0.2"
 htmlescape = "0.3"
 reqwest = {version = "0.11", default-features = false, features = ["socks", "blocking"]}
 rand = "0.8"
-md5 = "0.7"
+md-5 = "0.10"
 copypasta = {version = "0.8", optional = true}
 
 [target.'cfg(windows)'.dependencies]

--- a/src/ydclient.rs
+++ b/src/ydclient.rs
@@ -3,6 +3,7 @@
 use super::ydresponse::YdResponse;
 use crate::lang::is_chinese;
 use log::debug;
+use md5::{Md5, Digest};
 use rand::{thread_rng, Rng};
 use reqwest::blocking::Client;
 use reqwest::Url;
@@ -182,8 +183,13 @@ fn api(url: &str, query: &[(&str, &str)]) -> Result<Url, Box<dyn Error>> {
 }
 
 fn get_sign(api_key: &str, word: &str, salt: &str, app_sec: &str) -> String {
-    let sign = md5::compute(format!("{}{}{}{}", api_key, word, &salt, app_sec));
-    let sign = format!("{:x}", sign);
+    let sign_no_md5 = format!("{}{}{}{}", api_key, word, &salt, app_sec);
+
+    let mut hasher = Md5::new();
+    hasher.update(sign_no_md5);
+
+    let sign = hasher.finalize();
+    let sign = format!("{:2x}", sign);
 
     sign
 }


### PR DESCRIPTION
crate `md5` is out of maintenance after 2019, while `md-5` is still being maintained